### PR TITLE
Añade empaquetado Python básico

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md

--- a/doc2md.py
+++ b/doc2md.py
@@ -14,6 +14,7 @@ __version__ = "0.5.1"
 __license__ = "BSD 3-Clause Clear License"
 
 from contextlib import contextmanager
+import sys
 
 
 def format(doc, level, url=None):
@@ -104,10 +105,8 @@ def writer(output):
             yield f
 
 
-if __name__ == "__main__":
-    import sys
+def parse_args(argv=None):
     import argparse
-    import json
     from pathlib import Path
 
     parser = argparse.ArgumentParser(
@@ -128,10 +127,23 @@ if __name__ == "__main__":
         help="Output file. If not specified, the output is written to stdout",
     )
     parser.add_argument(
-        "-l", "--level", type=int, default=1, help="Start level for the headers"
+        "-l",
+        "--level",
+        type=int,
+        default=1,
+        help="Start level for the headers",
     )
     parser.add_argument("-u", "--url", default=None, help="URL template for the links")
-    args = parser.parse_args()
+    return parser.parse_args(argv)
 
+
+def main(argv=None):
+    import json
+
+    args = parse_args(argv)
     with reader(args.input) as r, writer(args.output) as w:
         w.writelines(format(json.load(r), args.level, args.url))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/md2html.py
+++ b/md2html.py
@@ -40,7 +40,9 @@ def fix_refs(txt):
     return txt
 
 
-def main(args):
+def main(args=None):
+    if args is None:
+        args = parse_args()
     with open(args.input, "r", encoding="utf-8") as f:
         txt = f.read()
 
@@ -107,14 +109,14 @@ def main(args):
     return 0
 
 
-def parse_args():
+def parse_args(argv=None):
     parser = argparse.ArgumentParser(
         description="Render markdown to html using the GitHub API"
     )
     parser.add_argument("input", metavar="INPUT_FILE.md", help="Input Markdown file")
     parser.add_argument("output", metavar="OUTPUT_FILE.html", help="Output HTML file")
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 if __name__ == "__main__":
-    exit(main(parse_args()))
+    raise SystemExit(main())

--- a/py2doc.py
+++ b/py2doc.py
@@ -83,9 +83,8 @@ def writer(output):
             yield f
 
 
-if __name__ == "__main__":
+def parse_args(argv=None):
     import argparse
-    import json
     from pathlib import Path
 
     parser = argparse.ArgumentParser(description="Extract docstrings from Python")
@@ -102,9 +101,19 @@ if __name__ == "__main__":
         help="Output file. If not specified, the output is written to stdout",
     )
     parser.add_argument(
-        "-e", "--encoding", default="utf-8", help="Encoding of the input files"
+        "-e",
+        "--encoding",
+        default="utf-8",
+        help="Encoding of the input files",
     )
-    args = parser.parse_args()
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    import json
+    from pathlib import Path
+
+    args = parse_args(argv)
 
     doc = {
         "version": __version__,
@@ -124,3 +133,7 @@ if __name__ == "__main__":
 
     with writer(args.output) as f:
         json.dump(doc, f, indent=2)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "microdoc"
+version = "0.5.1"
+description = "A minimalistic documentation generator"
+authors = [
+  { name = "Javier Escalada Gómez", email = "kerrigan29a@gmail.com" }
+]
+license = { file = "LICENSE" }
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent"
+]
+
+[tool.setuptools]
+py-modules = ["doc2md", "doctest_utils", "inject_usage", "md2html", "py2doc"]
+
+[project.scripts]
+py2doc = "py2doc:main"
+doc2md = "doc2md:main"
+md2html = "md2html:main"


### PR DESCRIPTION
## Summary
- agrega `pyproject.toml` y `MANIFEST.in`
- define `main()` y `parse_args()` en `doc2md.py` y `py2doc.py`
- ajusta `md2html.py` para aceptar argumentos opcionales
- añade import faltante de `sys`

## Testing
- `python -m pip install --quiet -e .`
- `python -m unittest discover -v`


------
https://chatgpt.com/codex/tasks/task_e_68553bb155bc832f99a229c430daf3f9