### PR TITLE
Update license field in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,12 +9,11 @@ description = "A minimalistic documentation generator"
 authors = [
   { name = "Javier Escalada Gómez", email = "kerrigan29a@gmail.com" }
 ]
-license = { file = "LICENSE" }
+license = "BSD-3-Clause-Clear"
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent"
 ]
 


### PR DESCRIPTION
## Summary
- use a license expression instead of a file reference in `pyproject.toml`
- remove the legacy license classifier

## Testing
- `python -m build`

------
https://chatgpt.com/codex/tasks/task_e_68554b56e714832fb0c1c5f5a2fe23bf